### PR TITLE
Usage doc - Fixing formatting typo in bullet 7

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -258,7 +258,6 @@ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d
   }
 }
 ```
-```
 ### 7. Create Observations associated to the Datastream and FeatureOfInterest.
 #### Request
 ```ssh


### PR DESCRIPTION
Bullet 7 is not shown as [6](https://github.com/mozilla-sensorweb/sensorthings/blob/master/doc/usage.md#6-create-a-featureofinterest)