### PR TITLE
[Issue #39] CreateObservations - create instances

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -76,9 +76,6 @@ export const modelNames = {
 };
 
 export const createObservations = 'CreateObservations';
-export const dataArray = 'dataArray';
-export const phenomenonTime = 'phenomenonTime';
-export const result = 'result';
 
 export const protocolHeader = 'x-forwarded-proto';
 export const hostHeader = 'x-forwarded-server';

--- a/src/extensions/data_array.js
+++ b/src/extensions/data_array.js
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import db         from '../models/db';
 import { datastream,
-         dataArray,
-         phenomenonTime,
-         result } from '../constants';
+         featureOfInterest,
+         iotId,
+         observations } from '../constants';
 import * as ERR   from '../errors';
 
 /**
@@ -20,6 +21,12 @@ import * as ERR   from '../errors';
  * with dataArray.
  *
  **/
+const dataArray = 'dataArray';
+const dataArrayIotCount = 'dataArray@iot.count';
+const phenomenonTime = 'phenomenonTime';
+const result = 'result';
+const featureOfInterestId = 'FeatureOfInterest/id';
+const exclude = null;
 
 export default () => {
   return (req, res) => {
@@ -49,11 +56,31 @@ export default () => {
         });
       };
 
+      // Validate input.
       // 2) Validate that each object in the input has the required properties.
       validateRequiredFields(body, [datastream, dataArray]);
       validateRequiredFields(body.components, [phenomenonTime, result]);
 
-      // 3) Validate that `body.components` and `body.dataArray` are the same
+      // Validate input.
+      // 3) Validate that the 'components' are one of:
+      //    'result', 'phenomenonTime', 'FeatureOfInterest/id'
+      body.components.forEach(component => {
+        switch(component) {
+          case result:
+          case phenomenonTime:
+          case featureOfInterestId:
+            break;
+          default:
+          throw Object.create({
+            name: ERR.BAD_REQUEST,
+            errno: ERR.ERRNO_BAD_REQUEST,
+            errors: 'Invalid component: ' + component
+          });
+        }
+      });
+
+      // Validate input.
+      // 4) Validate that `body.components` and `body.dataArray` are the same
       //    length.
       const componentsLength = body.components.length;
       body.dataArray.forEach(da => {
@@ -67,24 +94,82 @@ export default () => {
       });
     };
 
+    const createInstances = observationObjects => {
+      return new Promise((resolve, reject) => {
+        let dbInstancePromises = [];
+        db().then(models => {
+          observationObjects.forEach(observation => {
+            let newReq = Object.create(req);
+            newReq.body = observation;
+            dbInstancePromises.push(
+              models.createInstance(observations, newReq, exclude));
+          });
+          Promise.all(dbInstancePromises).then(instances => {
+            resolve(instances);
+          }).catch(ex => {
+            reject(ex);
+          });
+        }).catch(() => {
+          ERR.ApiError(res, 500, ERR.ERRNO_INTERNAL_ERROR, ERR.INTERNAL_ERROR);
+        });
+      });
+    };
+
+    const createObservations = body => {
+      let observationObjects = [];
+      const resultIndex = body.components.indexOf(result);
+      const featureOfInterestIndex =
+        body.components.indexOf(featureOfInterest + '/id');
+      const phenomenonTimeIndex = body.components.indexOf(phenomenonTime);
+      const dataArrayCount = body[dataArrayIotCount];
+
+      for (let i = 0; i < dataArrayCount; i++) {
+        let observation = {};
+        observation.Datastream = {};
+        observation.Datastream[iotId] = body.Datastream[iotId];
+        observation.result = body.dataArray[i][resultIndex];
+        observation.phenomenonTime = body.dataArray[i][phenomenonTimeIndex];
+
+        // If FeatureOfInterest relation is not specified,
+        // it will be extracted from Locations (i.e.,
+        // Datastreams-->Things-->Locations).
+        if (featureOfInterestIndex > -1) {
+          observation.FeatureOfInterest = {};
+          observation.FeatureOfInterest[iotId] =
+            body.dataArray[i][featureOfInterestIndex];
+        }
+        observationObjects.push(observation);
+      }
+
+      return observationObjects;
+    };
+
     const body = req.body;
 
     // Validate input.
     // 1) The body of request must be an array.
     if (!Array.isArray(body)) {
       return ERR.ApiError(res, 400, ERR.ERRNO_BAD_REQUEST,
-                   ERR.BAD_REQUEST, 'Input must be an array');
+                          ERR.BAD_REQUEST, 'Input must be an array');
     }
 
+    let observationObjects = [];
     for (let i = 0; i < body.length; i++) {
       try {
         validateBody(body[i]);
-      } catch (ex) {
+      } catch(ex) {
         return ERR.ApiError(res, 400, ex.errno, ex.name, ex.errors);
       }
+
+      observationObjects =
+        observationObjects.concat(createObservations(body[i]));
     }
 
-    ERR.ApiError(res, 501, ERR.ERRNO_NOT_IMPLEMENTED, ERR.NOT_IMPLEMENTED);
+    createInstances(observationObjects).then(() => {
+      ERR.ApiError(res, 501, ERR.ERRNO_NOT_IMPLEMENTED, ERR.NOT_IMPLEMENTED);
+    }).catch(ex => {
+      ERR.ApiError(res, 400, ex.errno, ex.name, ex.errors);
+    });
   };
 };
 

--- a/test/test_create_observations.js
+++ b/test/test_create_observations.js
@@ -1,7 +1,15 @@
 import app           from './server';
+import db            from '../src/models/db';
 import supertest     from 'supertest';
 import should        from 'should';
 import { createObservations } from '../src/constants';
+import { datastreams,
+         DatastreamsEntity,
+         entities,
+         featureOfInterest,
+         featuresOfInterest,
+         iotId,
+         FeaturesOfInterestEntity } from './constants';
 
 const endpoint = '/v1.0/' + createObservations;
 const server   = supertest.agent(app.listen(8889));
@@ -17,19 +25,37 @@ const postError = (done, body, code, message) => {
   });
 };
 
-const CreateObservationsRequestOneObservation = [{
+const CreateObservationsRequest = [{
   Datastream: { '@iot.id': 1 },
   components: [ 'phenomenonTime', 'result', 'FeatureOfInterest/id' ],
   'dataArray@iot.count': 2,
   dataArray: [ [ '2010-12-23T10:20:00-0700', 20, 1 ],
-    [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
+               [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
 }];
+
+/*
+const CreateObservationsRequestNoFoI = [{
+  Datastream: { '@iot.id': 1 },
+  components: [ 'phenomenonTime', 'result' ],
+  'dataArray@iot.count': 2,
+  dataArray: [ [ '2010-12-23T10:20:00-0700', 20 ],
+               [ '2010-12-23T10:21:00-0700', 30 ] ]
+}];
+*/
 
 const CreateObservationsRequestMissingDatastream = [{
   components: [ 'phenomenonTime', 'result', 'FeatureOfInterest/id' ],
   'dataArray@iot.count': 2,
   dataArray: [ [ '2010-12-23T10:20:00-0700', 20, 1 ],
-    [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
+               [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
+}];
+
+const CreateObservationsRequestMissingResult = [{
+  Datastream: { '@iot.id': 1 },
+  components: [ 'phenomenonTime', 'FeatureOfInterest/id' ],
+  'dataArray@iot.count': 2,
+  dataArray: [ [ '2010-12-23T10:20:00-0700', 1 ],
+               [ '2010-12-23T10:20:00-0700', 1 ] ]
 }];
 
 const CreateObservationsRequestMissingPhenomenonTime = [{
@@ -37,7 +63,25 @@ const CreateObservationsRequestMissingPhenomenonTime = [{
   components: [ 'result', 'FeatureOfInterest/id' ],
   'dataArray@iot.count': 2,
   dataArray: [ [ 20, 1 ],
-    [ 30, 1 ] ]
+               [ 30, 1 ] ]
+}];
+
+const badFoi = 'FeatureOfInterset/id';
+const CreateObservationsRequestInvalidFeatureOfInterestComponent = [{
+  Datastream: { '@iot.id': 1 },
+  components: [ 'phenomenonTime', 'result', badFoi ],
+  'dataArray@iot.count': 2,
+  dataArray: [ [ '2010-12-23T10:20:00-0700', 20, 1 ],
+    [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
+}];
+
+const unknownComponent = 'unknownComponenent';
+const CreateObservationsRequestUnknownComponent = [{
+  Datastream: { '@iot.id': 1 },
+  components: [ 'phenomenonTime', 'result', unknownComponent ],
+  'dataArray@iot.count': 2,
+  dataArray: [ [ '2010-12-23T10:20:00-0700', 20, 1 ],
+    [ '2010-12-23T10:21:00-0700', 30, 1 ] ]
 }];
 
 const CreateObservationsRequestComponentsDataArrayMismatch = [{
@@ -57,18 +101,112 @@ const CreateObservationsRequestNotArray = {
 };
 
 describe('CreateObservations tests', () => {
-  it('Valid request body', done => {
-    postError(done, CreateObservationsRequestOneObservation, 501);
+
+  beforeEach(done => {
+    db().then(models => {
+      models.sequelize.transaction(transaction => {
+        return Promise.all(Object.keys(entities).map(name => {
+          return models[name].destroy({ transaction, where: {} });
+        }));
+      }).then(() => done());
+    });
   });
+
+  it('Create observations specifying FeatureOfInterest', done => {
+    db().then(models => {
+      let body = JSON.parse(JSON.stringify(CreateObservationsRequest));
+
+      models[datastreams].create(DatastreamsEntity).then((relation) => {
+        body[0].Datastream[iotId] = relation.id;
+        models[featuresOfInterest].create(FeaturesOfInterestEntity).then(
+          (foiRelation) => {
+          const featureOfInterestIndex =
+            body[0].components.indexOf(featureOfInterest + '/id');
+          body[0].dataArray.forEach(da => {
+            da[featureOfInterestIndex] = foiRelation.id;
+          });
+          postError(done, body, 501);
+        });
+      });
+    });
+  });
+
+/*
+  it('Create observations without specifying FeatureOfInterest', done => {
+    db().then(models => {
+      let body = JSON.parse(JSON.stringify(CreateObservationsRequestNoFoI));
+      let datastreamsEntity = {
+         "unitOfMeasurement": {
+           "symbol": "μg/m³",
+           "name": "PM 2.5 Particulates (ug/m3)",
+           "definition": "http://unitsofmeasure.org/ucum.html"
+         },
+         "observationType":
+         "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+         "description": "Air quality readings",
+         "name": "air_quality_readings",
+         "Thing": {
+           "description": "A SensorWeb thing",
+           "name":"SensorWebThing",
+           "properties": {
+             "organisation": "Mozilla",
+             "owner": "Mozilla"
+           },
+           "Locations": [{
+             "description": "My backyard",
+             "name": "My backyard",
+             "encodingType": "application/vnd.geo+json",
+             "location": {
+               "type": "Point",
+               "coordinates": [-555.123, 66.234]
+             }
+           }]
+         },
+         "ObservedProperty": {
+           "name": "PM 2.5",
+           "description": "Particle pollution.",
+           "definition":
+             "https://airnow.gov/index.cfm?action=aqibasics.particle"
+         },
+         "Sensor": {
+           "description": "PM 2.5 sensor",
+           "name": "PM25sensor",
+           "encodingType": "application/pdf",
+           "metadata": "http://particle-sensor.com/"
+         }
+      };
+      models[datastreams].create(datastreamsEntity).then((relation) => {
+        body[0].Datastream[iotId] = relation.id;
+        console.log('body:', JSON.stringify(body));
+        postError(done, body, 501);
+      });
+    });
+  });
+*/
 
   it('Missing Datastream', done => {
     postError(done, CreateObservationsRequestMissingDatastream, 400,
               'Missing required field: Datastream');
   });
 
-  it('Missing PhenomenonTime', done => {
+  it('Missing result component', done => {
+    postError(done, CreateObservationsRequestMissingResult, 400,
+              'Missing required field: result');
+  });
+
+  it('Missing phenomenonTime component', done => {
     postError(done, CreateObservationsRequestMissingPhenomenonTime, 400,
               'Missing required field: phenomenonTime');
+  });
+
+  it('Invalid \'FeatureOfInterest/id\' component', done => {
+    postError(done, CreateObservationsRequestInvalidFeatureOfInterestComponent,
+              400, 'Invalid component: ' + badFoi);
+  });
+
+  it('Unknown component', done => {
+    postError(done, CreateObservationsRequestUnknownComponent,
+              400, 'Invalid component: ' + unknownComponent);
   });
 
   it('Components, dataArray mismatch', done => {
@@ -80,5 +218,39 @@ describe('CreateObservations tests', () => {
     postError(done, CreateObservationsRequestNotArray, 400,
               'Input must be an array');
   });
+
+  it('Invalid assoication: Datastream not found', done => {
+    db().then(models => {
+      let body = JSON.parse(JSON.stringify(CreateObservationsRequest));
+
+      models[featuresOfInterest].create(FeaturesOfInterestEntity).then(
+        (foiRelation) => {
+        const featureOfInterestIndex =
+          body[0].components.indexOf(featureOfInterest + '/id');
+        body[0].dataArray.forEach(da => {
+          da[featureOfInterestIndex] = foiRelation.id;
+        });
+        postError(done,
+                  body,
+                  400,
+                  'Invalid association. Datastream with id 1 not found');
+      });
+    });
+  });
+
+  it('Invalid assoication: FeatureOfInterest not found', done => {
+    db().then(models => {
+      let body = JSON.parse(JSON.stringify(CreateObservationsRequest));
+
+      models[datastreams].create(DatastreamsEntity).then((relation) => {
+        body[0].Datastream[iotId] = relation.id;
+        postError(done,
+                  body,
+                  400,
+                  'Invalid association. FeatureOfInterest with id 1 not found');
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
This PR creates the Observation instances for the CreateObservations endpoint. It also adds more validation (ensuring that all 'components' are valid). 

There is one test that is commented out because it is failing. The scenario is where the CreateObservations request doesn't include a FeatureOfInterest relation. This scenario works properly when hitting the server endpoint using curl. I'm not sure why it's failing during the test. The test is creating the Datastream instance using the same information I'm using to create the Datastream instance when running against my local server. When I create a Datastream instance by hitting my local server, the instance has links to a Thing and a Location. Yet, during the test, it seems the Datastream instance created doesn't contain a Thing or Location and therefore the server is not able to infer a FeatureOfInterest.